### PR TITLE
Feat: 특정 월의 사진인증 미션 조회 추가

### DIFF
--- a/src/main/java/com/devocean/Balbalm/feedMission/controller/FeedMissionController.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/controller/FeedMissionController.java
@@ -27,7 +27,7 @@ public class FeedMissionController {
 	}
 
 	@GetMapping()
-	public CommonResponse<MissionResponseDto> getMissionByMonth(@RequestParam int month) {
-		return new CommonResponse<>(feedMissionService.getMissionByMonth(month));
+	public CommonResponse<MissionResponseDto> getMissionByMonth(@RequestParam int year, @RequestParam int month) {
+		return new CommonResponse<>(feedMissionService.getMissionByMonth(year, month));
 	}
 }

--- a/src/main/java/com/devocean/Balbalm/feedMission/controller/FeedMissionController.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/controller/FeedMissionController.java
@@ -1,17 +1,19 @@
 package com.devocean.Balbalm.feedMission.controller;
 
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.devocean.Balbalm.feedMission.controller.dto.FeedMissionRequestDto;
+import com.devocean.Balbalm.feedMission.controller.dto.MissionResponseDto;
 import com.devocean.Balbalm.feedMission.service.FeedMissionService;
 import com.devocean.Balbalm.global.exception.CommonResponse;
 
 import lombok.RequiredArgsConstructor;
-import reactor.core.publisher.Mono;
 
 @RestController
 @RequestMapping("/api/feed-mission")
@@ -22,5 +24,10 @@ public class FeedMissionController {
 	public CommonResponse<Boolean> checkMissionComplete(@RequestHeader("Authorization") String token, @RequestBody FeedMissionRequestDto requestDto) {
 		boolean isCompleted = feedMissionService.checkMission(requestDto.getHashTag(), requestDto.getMissionId(), token.substring(7)).block();
 		return new CommonResponse<>(isCompleted);
+	}
+
+	@GetMapping()
+	public CommonResponse<MissionResponseDto> getMissionByMonth(@RequestParam int month) {
+		return new CommonResponse<>(feedMissionService.getMissionByMonth(month));
 	}
 }

--- a/src/main/java/com/devocean/Balbalm/feedMission/controller/dto/MissionResponseDto.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/controller/dto/MissionResponseDto.java
@@ -1,0 +1,18 @@
+package com.devocean.Balbalm.feedMission.controller.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MissionResponseDto {
+	private String mission;
+	private List<String> hashtag;
+	private int month;
+}

--- a/src/main/java/com/devocean/Balbalm/feedMission/controller/dto/MissionResponseDto.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/controller/dto/MissionResponseDto.java
@@ -15,4 +15,5 @@ public class MissionResponseDto {
 	private String mission;
 	private List<String> hashtag;
 	private int month;
+	private int year;
 }

--- a/src/main/java/com/devocean/Balbalm/feedMission/entity/FeedMission.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/entity/FeedMission.java
@@ -2,6 +2,7 @@ package com.devocean.Balbalm.feedMission.entity;
 
 import java.util.List;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -19,4 +20,6 @@ public class FeedMission {
 	private String content;
 	@OneToMany(mappedBy = "feedMission", fetch = FetchType.EAGER)
 	private List<HashTag> hashTags;
+	@Column(name = "month")
+	private int month;
 }

--- a/src/main/java/com/devocean/Balbalm/feedMission/entity/FeedMission.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/entity/FeedMission.java
@@ -22,4 +22,6 @@ public class FeedMission {
 	private List<HashTag> hashTags;
 	@Column(name = "month")
 	private int month;
+	@Column(name = "year")
+	private int year;
 }

--- a/src/main/java/com/devocean/Balbalm/feedMission/repository/FeedMissionRepository.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/repository/FeedMissionRepository.java
@@ -10,5 +10,5 @@ import com.devocean.Balbalm.feedMission.entity.FeedMission;
 @Repository
 public interface FeedMissionRepository extends JpaRepository<FeedMission, Long> {
 	Optional<FeedMission> findById(Long id);
-	Optional<FeedMission> findByMonth(int month);
+	Optional<FeedMission> findByYearAndMonth(int year, int month);
 }

--- a/src/main/java/com/devocean/Balbalm/feedMission/repository/FeedMissionRepository.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/repository/FeedMissionRepository.java
@@ -10,4 +10,5 @@ import com.devocean.Balbalm.feedMission.entity.FeedMission;
 @Repository
 public interface FeedMissionRepository extends JpaRepository<FeedMission, Long> {
 	Optional<FeedMission> findById(Long id);
+	Optional<FeedMission> findByMonth(int month);
 }

--- a/src/main/java/com/devocean/Balbalm/feedMission/service/FeedMissionService.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/service/FeedMissionService.java
@@ -2,12 +2,14 @@ package com.devocean.Balbalm.feedMission.service;
 
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.devocean.Balbalm.feedMission.controller.dto.MissionResponseDto;
 import com.devocean.Balbalm.feedMission.controller.dto.PostDto;
 import com.devocean.Balbalm.feedMission.entity.FeedMission;
 import com.devocean.Balbalm.feedMission.entity.FeedMissionUser;
@@ -74,5 +76,18 @@ public class FeedMissionService {
 			.retrieve()
 			.bodyToFlux(PostDto.class)
 			.collectList();
+	}
+
+	public MissionResponseDto getMissionByMonth(int month) {
+		FeedMission mission = feedMissionRepository.findByMonth(month)
+			.orElseThrow(() -> new RuntimeException("Mission Not Found"));
+
+		List<String> hashtags = mission.getHashTags().stream()
+			.map(hashTag -> hashTag.getName()).collect(Collectors.toList());
+		return MissionResponseDto.builder()
+			.month(month)
+			.hashtag(hashtags)
+			.mission(mission.getContent())
+			.build();
 	}
 }

--- a/src/main/java/com/devocean/Balbalm/feedMission/service/FeedMissionService.java
+++ b/src/main/java/com/devocean/Balbalm/feedMission/service/FeedMissionService.java
@@ -78,14 +78,15 @@ public class FeedMissionService {
 			.collectList();
 	}
 
-	public MissionResponseDto getMissionByMonth(int month) {
-		FeedMission mission = feedMissionRepository.findByMonth(month)
+	public MissionResponseDto getMissionByMonth(int year, int month) {
+		FeedMission mission = feedMissionRepository.findByYearAndMonth(year, month)
 			.orElseThrow(() -> new RuntimeException("Mission Not Found"));
 
 		List<String> hashtags = mission.getHashTags().stream()
 			.map(hashTag -> hashTag.getName()).collect(Collectors.toList());
 		return MissionResponseDto.builder()
-			.month(month)
+			.year(mission.getYear())
+			.month(mission.getMonth())
 			.hashtag(hashtags)
 			.mission(mission.getContent())
 			.build();


### PR DESCRIPTION
- 특정 달에 해당하는 사진 인증 미션 조회 API 추가
    - 2024년 12월에 해당하는 미션 조회하고 싶다면
`/mission/api/feed-mission?year=2024&month=12`

```json

{
    "isSuccess": true,
    "code": 200,
    "message": "요청에 성공하였습니다.",
    "result": {
        "mission": "테스트미션",
        "hashtag": [
            "lol"
        ],
        "month": 12,
        "year": 2024
    }
}

```